### PR TITLE
feat(homepage): add svg icons to card links for better visual appeal

### DIFF
--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -4,28 +4,33 @@
 {% endblock %}
 
 {% block stylesheets %}
-	{{ parent() }}
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;900&family=Kumar+One&family=Orbitron:wght@800;900&display=swap" rel="stylesheet">
-	<style>
-		.card-link {
-			display: block;
-			text-decoration: none;
-			background-color: rgba(15, 22, 36, 0.9);
-			padding: 2rem;
-			border-radius: 12px;
-			border: 2px solid #29FDFD;
-			box-shadow: 0 0 40px #29FDFD;
-			color: #fff;
-			cursor: pointer;
-			transition: transform 0.3s ease, box-shadow 0.3s ease;
-		}
-		.card-link:hover {
-			box-shadow: 0 0 60px #29FDFD;
-			transform: scale(1.02);
-		}
-	</style>
+    {{ parent() }}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;900&family=Kumar+One&family=Orbitron:wght@800;900&display=swap" rel="stylesheet">
+    <style>
+        .card-link {
+            display: block;
+            text-decoration: none;
+            background-color: rgba(15, 22, 36, 0.9);
+            padding: 2rem;
+            border-radius: 12px;
+            border: 2px solid #29FDFD;
+            box-shadow: 0 0 40px #29FDFD;
+            color: #fff;
+            cursor: pointer;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .card-link:hover {
+            box-shadow: 0 0 60px #29FDFD;
+            transform: scale(1.02);
+        }
+        /* Centrer le SVG dans la card */
+        .card-link svg {
+            display: block;
+            margin: 0 auto;
+        }
+    </style>
 {% endblock %}
 
 {% block body %}
@@ -43,6 +48,7 @@
 			<div class="cards-row" style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 2rem; width: 100%; max-width: 1000px;">
 				<a href="{{ path('app_lesson_index') }}" class="card-link">
 					<h2 class="text-[#29FDFD] text-2xl mb-3 text-center" style="font-family: 'Kumar One', serif;">Cours</h2>
+					<svg xmlns="http://www.w3.org/2000/svg" style="margin-bottom: 1rem;" width="11.1em" height="11em" viewbox="0 0 1696 1536"><path fill="currentColor" d="M1671 350q40 57 18 129l-275 906q-19 64-76.5 107.5T1215 1536H292q-77 0-148.5-53.5T44 1351q-24-67-2-127q0-4 3-27t4-37q1-8-3-21.5t-3-19.5q2-11 8-21t16.5-23.5T84 1051q23-38 45-91.5t30-91.5q3-10 .5-30t-.5-28q3-11 17-28t17-23q21-36 42-92t25-90q1-9-2.5-32t.5-28q4-13 22-30.5t22-22.5q19-26 42.5-84.5T372 283q1-8-3-25.5t-2-26.5q2-8 9-18t18-23t17-21q8-12 16.5-30.5t15-35t16-36t19.5-32T504.5 12t36-11.5T588 6l-1 3q38-9 51-9h761q74 0 114 56t18 130l-274 906q-36 119-71.5 153.5T1057 1280H188q-27 0-38 15q-11 16-1 43q24 70 144 70h923q29 0 56-15.5t35-41.5l300-987q7-22 5-57q38 15 59 43m-1064 2q-4 13 2 22.5t20 9.5h608q13 0 25.5-9.5T1279 352l21-64q4-13-2-22.5t-20-9.5H670q-13 0-25.5 9.5T628 288zm-83 256q-4 13 2 22.5t20 9.5h608q13 0 25.5-9.5T1196 608l21-64q4-13-2-22.5t-20-9.5H587q-13 0-25.5 9.5T545 544z"/></svg>
 					<p class="text-white/80 text-center" style="font-family: 'Inter', sans-serif;">
 						Apprends pas à pas avec des leçons interactives.
 					</p>
@@ -50,6 +56,7 @@
 
 				<a href="{{ path('app_language_index') }}" class="card-link">
 					<h2 class="text-[#29FDFD] text-2xl mb-3 text-center" style="font-family: 'Kumar One', serif;">Jeux</h2>
+                    <svg xmlns="http://www.w3.org/2000/svg" style="margin-bottom: 1rem;" width="11em" height="11em" viewBox="0 0 64 64"><path fill="currentColor" d="m61.876 44.196l-4.394-22.105c-.966-5.144-5.386-9.037-10.714-9.087V13H17.337c-5.375-.002-9.853 3.914-10.825 9.093L2.125 44.196c-.082.39-.13.79-.125 1.205C1.995 48.493 4.461 51 7.504 51c1.962 0 3.683-1.039 4.661-2.607l7.24-9.039a6.42 6.42 0 0 0 4.418 1.765c3.578-.002 6.479-2.949 6.479-6.591l3.5-.001c0 3.639 2.904 6.59 6.482 6.59a6.42 6.42 0 0 0 4.355-1.704l7.195 8.98c.977 1.564 2.7 2.607 4.657 2.607c3.043 0 5.512-2.507 5.509-5.601a5.8 5.8 0 0 0-.124-1.203m-40.955-23.01c.703-.716 1.506-.507 1.789.465l-.004 3.126c-.279.973-1.082 1.183-1.783.468l-.719-.73a1.866 1.866 0 0 1 0-2.6zm-5.117-3.427l3.072-.003c.955.282 1.16 1.102.455 1.817l-.712.728a1.794 1.794 0 0 1-2.56 0l-.718-.729c-.704-.715-.499-1.534.463-1.813m-2.047 7.483c-.705.718-1.511.508-1.79-.465l.004-3.126c.275-.973 1.081-1.182 1.784-.466l.716.729a1.864 1.864 0 0 1 0 2.6zm5.119 3.429l-3.076.003c-.958-.286-1.163-1.101-.458-1.817l.718-.729a1.795 1.795 0 0 1 2.559-.001l.715.73c.702.716.495 1.531-.458 1.814m4.942 10.268c-2.396.002-4.343-1.973-4.343-4.413c0-2.438 1.947-4.416 4.348-4.416c2.395.003 4.339 1.978 4.339 4.415c.003 2.442-1.944 4.418-4.344 4.414m20.263-19.406c.996.002 1.805.825 1.805 1.839c.002 1.019-.807 1.844-1.809 1.839c-1 .003-1.809-.82-1.809-1.837c.001-1.016.809-1.839 1.813-1.841m-3.797 19.408c-2.396 0-4.34-1.977-4.342-4.415c.002-2.438 1.945-4.416 4.342-4.416c2.401.002 4.346 1.978 4.344 4.416c0 2.438-1.942 4.413-4.344 4.415m3.963-10.208c-1 0-1.81-.826-1.81-1.841c-.001-1.017.81-1.841 1.81-1.841s1.808.824 1.811 1.841c0 1.016-.813 1.841-1.811 1.841m5.045-11.037c.999-.001 1.809.822 1.811 1.839c-.002 1.014-.812 1.839-1.811 1.839c-1 0-1.809-.825-1.809-1.839c-.002-1.018.805-1.843 1.809-1.839m.168 9.197c-.998.001-1.808-.822-1.805-1.838c-.003-1.017.807-1.842 1.807-1.839c.998-.002 1.81.82 1.81 1.836c-.001 1.018-.812 1.842-1.812 1.841"/></svg>
 					<p class="text-white/80 text-center" style="font-family: 'Inter', sans-serif;">
 						Joue et progresse en résolvant des défis.
 					</p>


### PR DESCRIPTION
Add SVG icons to the "Cours" and "Jeux" card links to enhance the visual design and user experience. The icons are centered within the cards using new CSS styling.