### PR TITLE
refactor(level): remove score field and clean up form type

### DIFF
--- a/src/Controller/LevelController.php
+++ b/src/Controller/LevelController.php
@@ -4,7 +4,6 @@ namespace App\Controller;
 
 use App\Entity\Level;
 use App\Form\LevelFormType;
-use App\Form\LevelType;
 use App\Repository\LevelRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/src/Form/LevelFormType.php
+++ b/src/Form/LevelFormType.php
@@ -8,8 +8,8 @@ use App\Entity\Language;
 use App\Entity\Level;
 use App\Entity\LevelType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -19,7 +19,6 @@ class LevelFormType extends AbstractType
     {
         $builder
             ->add('number', IntegerType::class)
-            ->add('score', IntegerType::class)
             ->add('avatar', EntityType::class, [
                 'class' => Avatar::class,
                 'choice_label' => 'name',
@@ -34,7 +33,6 @@ class LevelFormType extends AbstractType
             ])
             ->add('type', EntityType::class, [
                 'class' => LevelType::class,
-                'label' => 'Type de niveau',
                 'choice_label' => 'name',
             ])
         ;

--- a/templates/level/index.html.twig
+++ b/templates/level/index.html.twig
@@ -25,7 +25,7 @@
             </tr>
         {% else %}
             <tr>
-                <td colspan="4">no records found</td>
+                <td colspan="3">no records found</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/templates/level/show.html.twig
+++ b/templates/level/show.html.twig
@@ -15,10 +15,6 @@
                 <th>Number</th>
                 <td>{{ level.number }}</td>
             </tr>
-            <tr>
-                <th>Score</th>
-                <td>{{ level.score }}</td>
-            </tr>
         </tbody>
     </table>
 


### PR DESCRIPTION
- Remove score field from Level entity and related templates
- Clean up LevelFormType by removing unused imports and labels
- Adjust colspan in index template to match remaining columns