### PR TITLE
feat(levels): redesign level templates with new UI styling

### DIFF
--- a/templates/level/edit.html.twig
+++ b/templates/level/edit.html.twig
@@ -1,13 +1,70 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Edit Level{% endblock %}
+{% block title %}Modifier le Niveau - {{ level.number }}{% endblock %}
 
 {% block body %}
-    <h1>Edit Level</h1>
+	<div class="min-h-screen bg-[#0a0f18] text-white">
+		<div class="container mx-auto px-6 py-8">
+			<h1 class="text-center text-[#29FDFD] text-2xl font-bold mb-4">Modifier le Niveau</h1>
 
-    {{ include('level/_form.html.twig', {'button_label': 'Update'}) }}
+			<div class="overflow-auto rounded-lg p-4 border-2 border-[#29FDFD] shadow-[0_0_40px_rgba(41,253,253,0.45)] bg-[linear-gradient(180deg,#0a0f18_0%,#0b1220_100%)]">
+				{{ form_start(form) }}
+				<table class="w-full border-collapse">
+					<tbody>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Numéro</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.number) }}
+								{{ form_widget(form.number, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Avatar</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.avatar) }}
+								{{ form_widget(form.avatar, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Langage</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.language) }}
+								{{ form_widget(form.language, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Énoncé</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.enonce) }}
+								{{ form_widget(form.enonce, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Type</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.type) }}
+								{{ form_widget(form.type, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+					</tbody>
+				</table>
 
-    <a href="{{ path('app_level_index') }}">back to list</a>
+				<div class="flex justify-center mt-4 mb-4">
+					<button type="submit" class="px-3 py-2 rounded-md border-2 border-[#29FDFD] text-white no-underline shadow-[0_0_24px_rgba(41,253,253,0.3)] transition-all hover:text-[#29FDFD] hover:bg-[rgba(41,253,253,0.08)] hover:shadow-[0_0_40px_rgba(41,253,253,0.6)]">
+						Mettre à jour
+					</button>
+				</div>
 
-    {{ include('level/_delete_form.html.twig') }}
+				{{ form_rest(form) }}
+				{{ form_end(form) }}
+			</div>
+
+			<div class="flex gap-2 flex-wrap justify-center mt-4">
+				<a class="inline-block px-3 py-2 rounded-md border-2 border-[#29FDFD] text-white no-underline shadow-[0_0_24px_rgba(41,253,253,0.3)] transition-all hover:text-[#29FDFD] hover:bg-[rgba(41,253,253,0.08)] hover:shadow-[0_0_40px_rgba(41,253,253,0.6)]" href="{{ path('app_level_index') }}">Retour</a>
+				<a class="inline-block px-3 py-2 rounded-md border-2 border-[#FF0000] text-white no-underline shadow-[0_0_24px_rgba(255,0,0,0.3)] transition-all hover:text-[#FF0000] hover:bg-[rgba(255,0,0,0.08)] hover:shadow-[0_0_40px_rgba(255,0,0,0.6)]">
+					{{ include('level/_delete_form.html.twig') }}
+				</a>
+			</div>
+		</div>
+	</div>
 {% endblock %}

--- a/templates/level/index.html.twig
+++ b/templates/level/index.html.twig
@@ -93,6 +93,10 @@
                         <tr>
                             <th>Id</th>
                             <th>Numéro</th>
+                            <th>Avatar</th>
+                            <th>Langage</th>
+                            <th>Énoncé</th>
+                            <th>Type</th>
                             <th>Actions</th>
                         </tr>
                     </thead>
@@ -101,6 +105,10 @@
                         <tr>
                             <td>{{ level.id }}</td>
                             <td>{{ level.number }}</td>
+                            <td>{{ level.avatar.name }}</td>
+                            <td>{{ level.language.name }}</td>
+                            <td>{{ level.enonce.title }}</td>
+                            <td>{{ level.type.name }}</td>
                             <td class="actions">
                                 <a class="btn-link" href="{{ path('app_level_show', {'id': level.id}) }}">Voir</a>
                                 <a class="btn-link" href="{{ path('app_level_edit', {'id': level.id}) }}">Modifier</a>
@@ -108,7 +116,7 @@
                         </tr>
                     {% else %}
                         <tr>
-                            <td colspan="3" class="text-center">Aucune donnée disponible</td>
+                            <td colspan="7" class="text-center">Aucune donnée disponible</td>
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/templates/level/index.html.twig
+++ b/templates/level/index.html.twig
@@ -1,35 +1,125 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Level index{% endblock %}
+{% block title %}Niveaux{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <style>
+        .page-wrap {
+            min-height: calc(100vh - 64px);
+            background: #0a0f18;
+            color: #fff;
+        }
+        .header-title {
+            text-align: center;
+            color: #29FDFD;
+            font-size: 1.75rem;
+            margin-bottom: 1rem;
+            font-weight: 700;
+        }
+        .table-wrap {
+            overflow: auto;
+            border: 2px solid #29FDFD;
+            border-radius: 12px;
+            box-shadow: 0 0 40px rgba(41, 253, 253, 0.45);
+            background: linear-gradient(180deg, #0a0f18 0%, #0b1220 100%);
+        }
+        table.table-neon {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .table-neon thead th {
+            text-align: left;
+            padding: 12px 14px;
+            border-bottom: 1px solid #29FDFD;
+            color: #29FDFD;
+            background: rgba(41, 253, 253, 0.08);
+            white-space: nowrap;
+        }
+        .table-neon tbody td {
+            padding: 12px 14px;
+            border-bottom: 1px solid rgba(41, 253, 253, 0.15);
+            vertical-align: top;
+        }
+        .table-neon tbody tr:hover {
+            background: rgba(41, 253, 253, 0.05);
+        }
+        .actions {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+        .btn-link {
+            display: inline-block;
+            padding: 8px 12px;
+            border-radius: 8px;
+            color: #fff;
+            border: 1px solid #29FDFD;
+            text-decoration: none;
+            transition: all 160ms ease;
+        }
+        .btn-link:hover {
+            color: #29FDFD;
+            background: rgba(41, 253, 253, 0.08);
+            box-shadow: inset 0 0 0 1px rgba(41, 253, 253, 0.25);
+        }
+        .create-btn {
+            display: inline-block;
+            margin-top: 1rem;
+            padding: 10px 14px;
+            border: 2px solid #29FDFD;
+            border-radius: 10px;
+            color: #fff;
+            text-decoration: none;
+            box-shadow: 0 0 24px rgba(41, 253, 253, 0.3);
+            transition: all 160ms ease;
+        }
+        .create-btn:hover {
+            color: #29FDFD;
+            box-shadow: 0 0 40px rgba(41, 253, 253, 0.6);
+            transform: translateY(-1px);
+        }
+    </style>
+{% endblock %}
 
 {% block body %}
-    <h1>Level index</h1>
+    <div class="page-wrap">
+        <div class="container mx-auto px-6 py-8">
+            <h1 class="header-title">Niveaux</h1>
 
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Id</th>
-                <th>Number</th>
-                <th>actions</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for level in levels %}
-            <tr>
-                <td>{{ level.id }}</td>
-                <td>{{ level.number }}</td>
-                <td>
-                    <a href="{{ path('app_level_show', {'id': level.id}) }}">show</a>
-                    <a href="{{ path('app_level_edit', {'id': level.id}) }}">edit</a>
-                </td>
-            </tr>
-        {% else %}
-            <tr>
-                <td colspan="3">no records found</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
+            <div class="table-wrap">
+                <table class="table-neon">
+                    <thead>
+                        <tr>
+                            <th>Id</th>
+                            <th>Numéro</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for level in levels %}
+                        <tr>
+                            <td>{{ level.id }}</td>
+                            <td>{{ level.number }}</td>
+                            <td class="actions">
+                                <a class="btn-link" href="{{ path('app_level_show', {'id': level.id}) }}">Voir</a>
+                                <a class="btn-link" href="{{ path('app_level_edit', {'id': level.id}) }}">Modifier</a>
+                            </td>
+                        </tr>
+                    {% else %}
+                        <tr>
+                            <td colspan="3" class="text-center">Aucune donnée disponible</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
 
-    <a href="{{ path('app_level_new') }}">Create new</a>
+            <a class="create-btn" href="{{ path('app_level_new') }}">
+                <svg xmlns="http://www.w3.org/2000/svg" width="0.88em" height="1em" viewBox="0 0 448 512">
+                    <path fill="currentColor" d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32v160H32c-17.7 0-32 14.3-32 32s14.3 32 32 32h160v160c0 17.7 14.3 32 32 32s32-14.3 32-32V288h160c17.7 0 32-14.3 32-32s-14.3-32-32-32H256z"/>
+                </svg>
+            </a>
+        </div>
+    </div>
 {% endblock %}

--- a/templates/level/new.html.twig
+++ b/templates/level/new.html.twig
@@ -1,11 +1,67 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}New Level{% endblock %}
+{% block title %}Nouveau Niveau{% endblock %}
 
 {% block body %}
-    <h1>Create new Level</h1>
+	<div class="min-h-screen bg-[#0a0f18] text-white">
+		<div class="container mx-auto px-6 py-8">
+			<h1 class="text-center text-[#29FDFD] text-2xl font-bold mb-4">Créer un Niveau</h1>
 
-    {{ include('level/_form.html.twig') }}
+			<div class="overflow-auto rounded-lg p-4 border-2 border-[#29FDFD] shadow-[0_0_40px_rgba(41,253,253,0.45)] bg-[linear-gradient(180deg,#0a0f18_0%,#0b1220_100%)]">
+				{{ form_start(form) }}
+				<table class="w-full border-collapse">
+					<tbody>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Numéro</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.number) }}
+								{{ form_widget(form.number, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Avatar</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.avatar) }}
+								{{ form_widget(form.avatar, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Langage</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.language) }}
+								{{ form_widget(form.language, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Énoncé</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.enonce) }}
+								{{ form_widget(form.enonce, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Type</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">
+								{{ form_errors(form.type) }}
+								{{ form_widget(form.type, {'attr': {'class': 'bg-transparent text-white border border-[#29FDFD] rounded-md px-3 py-2 w-full'}}) }}
+							</td>
+						</tr>
+					</tbody>
+				</table>
 
-    <a href="{{ path('app_level_index') }}">back to list</a>
+				<div class="flex justify-center mt-4 mb-4">
+					<button type="submit" class="px-3 py-2 rounded-md border-2 border-[#29FDFD] text-white no-underline shadow-[0_0_24px_rgba(41,253,253,0.3)] transition-all hover:text-[#29FDFD] hover:bg-[rgba(41,253,253,0.08)] hover:shadow-[0_0_40px_rgba(41,253,253,0.6)]">
+						Créer
+					</button>
+				</div>
+
+				{{ form_rest(form) }}
+				{{ form_end(form) }}
+			</div>
+
+			<div class="flex gap-2 flex-wrap justify-center mt-4">
+				<a class="inline-block px-3 py-2 rounded-md border-2 border-[#29FDFD] text-white no-underline shadow-[0_0_24px_rgba(41,253,253,0.3)] transition-all hover:text-[#29FDFD] hover:bg-[rgba(41,253,253,0.08)] hover:shadow-[0_0_40px_rgba(41,253,253,0.6)]" href="{{ path('app_level_index') }}">Retour</a>
+			</div>
+		</div>
+	</div>
 {% endblock %}

--- a/templates/level/show.html.twig
+++ b/templates/level/show.html.twig
@@ -1,26 +1,32 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Level{% endblock %}
+{% block title %}Niveau - {{ level.number }}{% endblock %}
 
 {% block body %}
-    <h1>Level</h1>
+	<div class="min-h-screen bg-[#0a0f18] text-white">
+		<div class="container mx-auto px-6 py-8">
+			<div class="overflow-auto rounded-lg">
+				<table class="w-full border-collapse">
+					<tbody>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Id</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">{{ level.id }}</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Numéro</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">{{ level.number }}</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
 
-    <table class="table">
-        <tbody>
-            <tr>
-                <th>Id</th>
-                <td>{{ level.id }}</td>
-            </tr>
-            <tr>
-                <th>Number</th>
-                <td>{{ level.number }}</td>
-            </tr>
-        </tbody>
-    </table>
-
-    <a href="{{ path('app_level_index') }}">back to list</a>
-
-    <a href="{{ path('app_level_edit', {'id': level.id}) }}">edit</a>
-
-    {{ include('level/_delete_form.html.twig') }}
+			<div class="flex gap-2 flex-wrap justify-center mt-4">
+				<a class="inline-block px-3 py-2 rounded-md border-2 border-[#29FDFD] text-white no-underline shadow-[0_0_24px_rgba(41,253,253,0.3)] transition-all hover:text-[#29FDFD] hover:bg-[rgba(41,253,253,0.08)] hover:shadow-[0_0_40px_rgba(41,253,253,0.6)]" href="{{ path('app_level_index') }}">Retour</a>
+				<a class="inline-block px-3 py-2 rounded-md border-2 border-[#29FDFD] text-white no-underline shadow-[0_0_24px_rgba(41,253,253,0.3)] transition-all hover:text-[#29FDFD] hover:bg-[rgba(41,253,253,0.08)] hover:shadow-[0_0_40px_rgba(41,253,253,0.6)]" href="{{ path('app_level_edit', {'id': level.id}) }}">Modifier</a>
+				<a class="inline-block px-3 py-2 rounded-md border-2 border-[#FF0000] text-white no-underline shadow-[0_0_24px_rgba(255,0,0,0.3)] transition-all hover:text-[#FF0000] hover:bg-[rgba(255,0,0,0.08)] hover:shadow-[0_0_40px_rgba(255,0,0,0.6)]">
+					{{ include('level/_delete_form.html.twig') }}
+				</a>
+			</div>
+		</div>
+	</div>
 {% endblock %}

--- a/templates/level/show.html.twig
+++ b/templates/level/show.html.twig
@@ -16,6 +16,22 @@
 							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Numéro</th>
 							<td class="px-4 py-3 border border-[#29FDFD] align-top">{{ level.number }}</td>
 						</tr>
+                        <tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Language</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">{{ level.avatar.name }}</td>
+						</tr>
+						<tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Language</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">{{ level.language.name }}</td>
+						</tr>
+                        <tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Enoncé</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">{{ level.enonce.title }}</td>
+						</tr>
+                        <tr class="even:bg-[rgba(41,253,253,0.06)] hover:bg-[rgba(41,253,253,0.05)]">
+							<th class="text-left px-4 py-3 border border-[#29FDFD] text-[#29FDFD] bg-[rgba(41,253,253,0.08)] whitespace-nowrap w-56">Type</th>
+							<td class="px-4 py-3 border border-[#29FDFD] align-top">{{ level.type.name }}</td>
+						</tr>
 					</tbody>
 				</table>
 			</div>


### PR DESCRIPTION
Redesign all level-related templates (show, new, edit, index) with a consistent dark theme and neon styling. Includes:
- Updated page titles and translations
- Responsive table layouts with hover effects
- Custom form styling with neon borders
- Improved button styling and interactions
- Added custom stylesheet for index page