### PR TITLE
fix(security): correct path pattern for public lessons access

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -32,7 +32,7 @@ security:
     # Note: Only the *first* access control that matches will be used
     access_control:
         # pour les lessons accessible sans etre connecté
-        - { path: ^/lessons, roles: PUBLIC_ACCESS }
+        - { path: ^/lesson, roles: PUBLIC_ACCESS }
         - { path: ^/login, roles: PUBLIC_ACCESS } # Allows accessing the login page
         - { path: ^/register, roles: PUBLIC_ACCESS } # Allows accessing the registration page
         # - { path: ^/admin, roles: ROLE_ADMIN }


### PR DESCRIPTION
The path pattern was updated from '/lessons' to '/lesson' to match the actual route structure and ensure proper access control